### PR TITLE
Notegraph update

### DIFF
--- a/src/NoteGraph.cpp
+++ b/src/NoteGraph.cpp
@@ -4,21 +4,26 @@
 
 NoteGraph::NoteGraph() {
     for (int i=0; i<static_cast<int>(Note::TOTAL); i++) {
-        m_graph.insert(std::pair<Note, NotesSet>(static_cast<Note>(i), NotesSet()));
-        //m_graph.insert(std::pair<Note, NotesSet)
+        m_graph.insert(std::pair<Note, std::vector<Note>>(static_cast<Note>(i), std::vector<Note>()));
+
     }
 }
 
-const NotesSet& NoteGraph::getConnectedNotes(Note from) {
+const std::vector<Note>& NoteGraph::getConnectedNotes(Note from) {
     return m_graph[from];
 }
 
 void NoteGraph::connect(Note from, Note to) {
-    m_graph[from].insert(to);
+    m_graph[from].push_back(to);
 }
 
 void NoteGraph::disconnect(Note from, Note to) {
-    m_graph[from].erase(to);
+    for (auto it=m_graph[from].cbegin(); it != m_graph[from].cend(); it++) {
+        if (*it == to) {
+            m_graph[from].erase(it);
+            return;
+        }
+    }
 }
 
 void NoteGraph::disconnectAll(Note from) {

--- a/src/NoteGraph.h
+++ b/src/NoteGraph.h
@@ -35,7 +35,8 @@ const std::unordered_map<Note, std::string, EnumClassHash> note_map {
         {Note::Sa, "Sa"}, {Note::re, "re"}, {Note::Re, "Re"},
         {Note::ga, "ga"}, {Note::Ga, "Ga"}, {Note::Ma, "Ma"},
         {Note::ma, "ma"}, {Note::Pa, "Pa"}, {Note::dha, "dha"},
-        {Note::Dha, "Dha"}, {Note::ni, "ni"}, {Note::Ni, "Ni"}
+        {Note::Dha, "Dha"}, {Note::ni, "ni"}, {Note::Ni, "Ni"},
+        {Note::TOTAL, "TOTAL"}, {Note::NONE, "NONE"}
 };
 
 

--- a/src/NoteGraph.h
+++ b/src/NoteGraph.h
@@ -40,8 +40,7 @@ const std::unordered_map<Note, std::string, EnumClassHash> note_map {
 };
 
 
-using NotesSet = std::unordered_set<Note, EnumClassHash>;
-using Graph = std::map<Note, NotesSet>;
+using Graph = std::map<Note, std::vector<Note>>;
 
 /*
  * Builds a graph containing paths from a note to note. Each note can go to multiple unique notes.
@@ -51,7 +50,7 @@ public:
     NoteGraph();
     //TODO: Destructor needed ????
 
-    const NotesSet & getConnectedNotes(Note from);
+    const std::vector<Note> & getConnectedNotes(Note from);
     void connect(Note from, Note to);
     void disconnect(Note from, Note to);
     void disconnectAll(Note from);

--- a/src/RaagEngine.cpp
+++ b/src/RaagEngine.cpp
@@ -66,10 +66,8 @@ void RaagEngine::reset() {
     m_currentOctave = 4;
     m_transposition = 0;
     m_currentNote = Note::Sa;
-    for (int i=0; i<static_cast<int>(Note::TOTAL); i++) {
-        m_aroha.disconnectAll(static_cast<Note>(i));
-        m_avroha.disconnectAll(static_cast<Note>(i));
-    }
+    m_aroha.reset();
+    m_avroha.reset();
     initLastNotes();
 }
 

--- a/src/RaagEngine.cpp
+++ b/src/RaagEngine.cpp
@@ -4,11 +4,7 @@
 
 #include "RaagEngine.h"
 
-
-RaagEngine::RaagEngine() :
-    m_lastNoteAroha(Note::NONE),
-    m_lastNoteAvroha(Note::NONE)
-{
+RaagEngine::RaagEngine() {
     initLastNotes();
 }
 

--- a/src/RaagEngine.cpp
+++ b/src/RaagEngine.cpp
@@ -80,11 +80,10 @@ bool RaagEngine::stepUp() {
 
     if(m_currentNote == m_lastNoteAroha)
         incOctave();
+
     randomGen.setRange(0, static_cast<int>(nextNotes.size())-1);
-    auto offset = randomGen.generate();
-    auto it = nextNotes.cbegin();
-    std::advance(it, offset);    //TODO: This is expensive, linear complexity.
-    m_currentNote = *it;
+    auto randomIdx = randomGen.generate();
+    m_currentNote = nextNotes[randomIdx];
     return true;
 }
 
@@ -95,11 +94,10 @@ bool RaagEngine::stepDown() {
 
     if(m_currentNote == m_lastNoteAvroha)
         decOctave();
+
     randomGen.setRange(0, static_cast<int>(nextNotes.size())-1);
-    auto offset = randomGen.generate();
-    auto it = nextNotes.cbegin();
-    std::advance(it, offset);    //TODO: This is expensive, linear complexity.
-    m_currentNote = *it;
+    auto randomIdx = randomGen.generate();
+    m_currentNote = nextNotes[randomIdx];
     return true;
 }
 

--- a/src/RaagEngine.h
+++ b/src/RaagEngine.h
@@ -37,8 +37,8 @@ private:
     NoteGraph m_aroha;
     NoteGraph m_avroha;
     Note m_currentNote = Note::Sa;
-    Note m_lastNoteAroha;
-    Note m_lastNoteAvroha;
+    Note m_lastNoteAroha = Note::NONE;
+    Note m_lastNoteAvroha = Note::NONE;
     int m_transposition = 0;
     int m_currentOctave = 4;
     int m_minOctave = 3;


### PR DESCRIPTION
- `NoteGraph` now allows duplicate connections. Internally set replaced by a vector.
- `RaagEngine::stepUp` and `RaagEngine::stepDown` updated to work with vector version of `NoteGraph`.

